### PR TITLE
Removing y_true and type_of_target from _get_response_values

### DIFF
--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -1292,17 +1292,18 @@ class CalibrationDisplay:
         method_name = f"{cls.__name__}.from_estimator"
         check_matplotlib_support(method_name)
 
-        target_type = type_of_target(y)
         if not is_classifier(estimator):
             raise ValueError("'estimator' should be a fitted classifier.")
+
+        check_is_fitted(estimator)
+        if len(estimator.classes_) != 2:
+            raise ValueError("Estimator must be a binary classifier.")
 
         y_prob, pos_label = _get_response_values(
             estimator,
             X,
-            y,
             response_method="predict_proba",
             pos_label=pos_label,
-            target_type=target_type,
         )
 
         name = name if name is not None else estimator.__class__.__name__

--- a/sklearn/metrics/_plot/base.py
+++ b/sklearn/metrics/_plot/base.py
@@ -1,63 +1,19 @@
 from ...base import is_classifier
+from ...utils._response import _get_response_values
+from ...utils.validation import check_is_fitted
 
 
-def _check_classifier_response_method(estimator, response_method):
-    """Return prediction method from the response_method
-
-    Parameters
-    ----------
-    estimator: object
-        Classifier to check
-
-    response_method: {'auto', 'predict_proba', 'decision_function'}
-        Specifies whether to use :term:`predict_proba` or
-        :term:`decision_function` as the target response. If set to 'auto',
-        :term:`predict_proba` is tried first and if it does not exist
-        :term:`decision_function` is tried next.
-
-    Returns
-    -------
-    prediction_method: callable
-        prediction method of estimator
-    """
-
-    if response_method not in ("predict_proba", "decision_function", "auto"):
-        raise ValueError(
-            "response_method must be 'predict_proba', 'decision_function' or 'auto'"
-        )
-
-    error_msg = "response method {} is not defined in {}"
-    if response_method != "auto":
-        prediction_method = getattr(estimator, response_method, None)
-        if prediction_method is None:
-            raise ValueError(
-                error_msg.format(response_method, estimator.__class__.__name__)
-            )
-    else:
-        predict_proba = getattr(estimator, "predict_proba", None)
-        decision_function = getattr(estimator, "decision_function", None)
-        prediction_method = predict_proba or decision_function
-        if prediction_method is None:
-            raise ValueError(
-                error_msg.format(
-                    "decision_function or predict_proba", estimator.__class__.__name__
-                )
-            )
-
-    return prediction_method
-
-
-def _get_response(X, estimator, response_method, pos_label=None):
+def _get_response_binary(estimator, X, response_method, pos_label=None):
     """Return response and positive label.
 
     Parameters
     ----------
-    X : {array-like, sparse matrix} of shape (n_samples, n_features)
-        Input values.
-
     estimator : estimator instance
         Fitted classifier or a fitted :class:`~sklearn.pipeline.Pipeline`
         in which the last estimator is a classifier.
+
+    X : {array-like, sparse matrix} of shape (n_samples, n_features)
+        Input values.
 
     response_method: {'auto', 'predict_proba', 'decision_function'}
         Specifies whether to use :term:`predict_proba` or
@@ -85,32 +41,16 @@ def _get_response(X, estimator, response_method, pos_label=None):
         f" {estimator.__class__.__name__}"
     )
 
-    if not is_classifier(estimator):
+    check_is_fitted(estimator)
+    if not is_classifier(estimator) or len(estimator.classes_) != 2:
         raise ValueError(classification_error)
 
-    prediction_method = _check_classifier_response_method(estimator, response_method)
-    y_pred = prediction_method(X)
-    if pos_label is not None:
-        try:
-            class_idx = estimator.classes_.tolist().index(pos_label)
-        except ValueError as e:
-            raise ValueError(
-                "The class provided by 'pos_label' is unknown. Got "
-                f"{pos_label} instead of one of {set(estimator.classes_)}"
-            ) from e
-    else:
-        class_idx = 1
-        pos_label = estimator.classes_[class_idx]
+    if response_method == "auto":
+        response_method = ["predict_proba", "decision_function"]
 
-    if y_pred.ndim != 1:  # `predict_proba`
-        y_pred_shape = y_pred.shape[1]
-        if y_pred_shape != 2:
-            raise ValueError(
-                f"{classification_error} fit on multiclass ({y_pred_shape} classes)"
-                " data"
-            )
-        y_pred = y_pred[:, class_idx]
-    elif pos_label == estimator.classes_[0]:  # `decision_function`
-        y_pred *= -1
-
-    return y_pred, pos_label
+    return _get_response_values(
+        estimator,
+        X,
+        response_method,
+        pos_label=pos_label,
+    )

--- a/sklearn/metrics/_plot/det_curve.py
+++ b/sklearn/metrics/_plot/det_curve.py
@@ -1,6 +1,6 @@
 import scipy as sp
 
-from .base import _get_response
+from .base import _get_response_binary
 
 from .. import det_curve
 from .._base import _check_pos_label_consistency
@@ -168,9 +168,9 @@ class DetCurveDisplay:
 
         name = estimator.__class__.__name__ if name is None else name
 
-        y_pred, pos_label = _get_response(
-            X,
+        y_pred, pos_label = _get_response_binary(
             estimator,
+            X,
             response_method,
             pos_label=pos_label,
         )

--- a/sklearn/metrics/_plot/precision_recall_curve.py
+++ b/sklearn/metrics/_plot/precision_recall_curve.py
@@ -1,5 +1,5 @@
 from sklearn.base import is_classifier
-from .base import _get_response
+from .base import _get_response_binary
 
 from .. import average_precision_score
 from .. import precision_recall_curve
@@ -271,9 +271,9 @@ class PrecisionRecallDisplay:
         check_matplotlib_support(method_name)
         if not is_classifier(estimator):
             raise ValueError(f"{method_name} only supports classifiers")
-        y_pred, pos_label = _get_response(
-            X,
+        y_pred, pos_label = _get_response_binary(
             estimator,
+            X,
             response_method,
             pos_label=pos_label,
         )

--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -1,4 +1,4 @@
-from .base import _get_response
+from .base import _get_response_binary
 
 from .. import auc
 from .. import roc_curve
@@ -231,9 +231,9 @@ class RocCurveDisplay:
 
         name = estimator.__class__.__name__ if name is None else name
 
-        y_pred, pos_label = _get_response(
-            X,
+        y_pred, pos_label = _get_response_binary(
             estimator,
+            X,
             response_method=response_method,
             pos_label=pos_label,
         )

--- a/sklearn/metrics/_plot/tests/test_base.py
+++ b/sklearn/metrics/_plot/tests/test_base.py
@@ -5,71 +5,74 @@ from sklearn.datasets import load_iris
 from sklearn.linear_model import LogisticRegression
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 
-from sklearn.metrics._plot.base import _get_response
+from sklearn.metrics._plot.base import _get_response_binary
+
+X, y = load_iris(return_X_y=True)
+X_binary, y_binary = X[:100], y[:100]
 
 
 @pytest.mark.parametrize(
-    "estimator, err_msg, params",
+    "estimator, X, y, err_msg, params",
     [
         (
             DecisionTreeRegressor(),
+            X_binary,
+            y_binary,
             "Expected 'estimator' to be a binary classifier",
             {"response_method": "auto"},
         ),
         (
             DecisionTreeClassifier(),
-            "The class provided by 'pos_label' is unknown.",
+            X_binary,
+            y_binary,
+            r"pos_label=unknown is not a valid label: It should be one of \[0 1\]",
             {"response_method": "auto", "pos_label": "unknown"},
         ),
         (
             DecisionTreeClassifier(),
-            "fit on multiclass",
+            X,
+            y,
+            "Expected 'estimator' to be a binary classifier, but got"
+            " DecisionTreeClassifier",
             {"response_method": "predict_proba"},
         ),
     ],
 )
-def test_get_response_error(estimator, err_msg, params):
-    """Check that we raise the proper error messages in `_get_response`."""
-    X, y = load_iris(return_X_y=True)
+def test_get_response_error(estimator, X, y, err_msg, params):
+    """Check that we raise the proper error messages in `_get_response_binary`."""
 
     estimator.fit(X, y)
     with pytest.raises(ValueError, match=err_msg):
-        _get_response(X, estimator, **params)
+        _get_response_binary(estimator, X, **params)
 
 
 def test_get_response_predict_proba():
-    """Check the behaviour of `_get_response` using `predict_proba`."""
-    X, y = load_iris(return_X_y=True)
-    X_binary, y_binary = X[:100], y[:100]
-
+    """Check the behaviour of `_get_response_binary` using `predict_proba`."""
     classifier = DecisionTreeClassifier().fit(X_binary, y_binary)
-    y_proba, pos_label = _get_response(
-        X_binary, classifier, response_method="predict_proba"
+    y_proba, pos_label = _get_response_binary(
+        classifier, X_binary, response_method="predict_proba"
     )
     np.testing.assert_allclose(y_proba, classifier.predict_proba(X_binary)[:, 1])
     assert pos_label == 1
 
-    y_proba, pos_label = _get_response(
-        X_binary, classifier, response_method="predict_proba", pos_label=0
+    y_proba, pos_label = _get_response_binary(
+        classifier, X_binary, response_method="predict_proba", pos_label=0
     )
     np.testing.assert_allclose(y_proba, classifier.predict_proba(X_binary)[:, 0])
     assert pos_label == 0
 
 
 def test_get_response_decision_function():
-    """Check the behaviour of `get_response` using `decision_function`."""
-    X, y = load_iris(return_X_y=True)
-    X_binary, y_binary = X[:100], y[:100]
-
+    """Check the behaviour of `_get_response_binary` using `decision_function`."""
     classifier = LogisticRegression().fit(X_binary, y_binary)
-    y_score, pos_label = _get_response(
-        X_binary, classifier, response_method="decision_function"
+    y_score, pos_label = _get_response_binary(
+        classifier, X_binary, response_method="decision_function"
     )
     np.testing.assert_allclose(y_score, classifier.decision_function(X_binary))
     assert pos_label == 1
 
-    y_score, pos_label = _get_response(
-        X_binary, classifier, response_method="decision_function", pos_label=0
+    y_score, pos_label = _get_response_binary(
+        classifier, X_binary, response_method="decision_function", pos_label=0
     )
     np.testing.assert_allclose(y_score, classifier.decision_function(X_binary) * -1)
     assert pos_label == 0

--- a/sklearn/metrics/_plot/tests/test_common_curve_display.py
+++ b/sklearn/metrics/_plot/tests/test_common_curve_display.py
@@ -48,20 +48,20 @@ def test_display_curve_error_non_binary(pyplot, data, Display):
     [
         (
             "predict_proba",
-            "response method predict_proba is not defined in MyClassifier",
+            "MyClassifier has none of the following attributes: predict_proba.",
         ),
         (
             "decision_function",
-            "response method decision_function is not defined in MyClassifier",
+            "MyClassifier has none of the following attributes: decision_function.",
         ),
         (
             "auto",
-            "response method decision_function or predict_proba is not "
-            "defined in MyClassifier",
+            "MyClassifier has none of the following attributes: predict_proba,"
+            " decision_function.",
         ),
         (
             "bad_method",
-            "response_method must be 'predict_proba', 'decision_function' or 'auto'",
+            "MyClassifier has none of the following attributes: bad_method.",
         ),
     ],
 )
@@ -86,7 +86,7 @@ def test_display_curve_error_no_response(
 
     clf = MyClassifier().fit(X, y)
 
-    with pytest.raises(ValueError, match=msg):
+    with pytest.raises(AttributeError, match=msg):
         Display.from_estimator(clf, X, y, response_method=response_method)
 
 

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -624,7 +624,7 @@ def test_calibration_display_validation(pyplot, iris_data, iris_data_binary):
     with pytest.raises(ValueError, match=msg):
         CalibrationDisplay.from_estimator(reg, X, y)
 
-    clf = LinearSVC().fit(X, y)
+    clf = LinearSVC().fit(X_binary, y_binary)
     msg = "has none of the following attributes: predict_proba."
     with pytest.raises(AttributeError, match=msg):
         CalibrationDisplay.from_estimator(clf, X, y)
@@ -642,7 +642,7 @@ def test_calibration_display_non_binary(pyplot, iris_data, constructor_name):
     y_prob = clf.predict_proba(X)
 
     if constructor_name == "from_estimator":
-        msg = "The target y is not binary. Got multiclass type of target."
+        msg = "Estimator must be a binary classifier."
         with pytest.raises(ValueError, match=msg):
             CalibrationDisplay.from_estimator(clf, X, y)
     else:

--- a/sklearn/utils/_response.py
+++ b/sklearn/utils/_response.py
@@ -1,16 +1,13 @@
 import numpy as np
 
-from .multiclass import type_of_target
 from .validation import _check_response_method
 
 
 def _get_response_values(
     estimator,
     X,
-    y_true,
     response_method,
     pos_label=None,
-    target_type=None,
 ):
     """Compute the response values of a classifier or a regressor.
 
@@ -34,9 +31,6 @@ def _get_response_values(
     X : {array-like, sparse matrix} of shape (n_samples, n_features)
         Input values.
 
-    y_true : array-like of shape (n_samples,)
-        The true label.
-
     response_method : {"predict_proba", "decision_function", "predict"} or \
             list of such str
         Specifies the response method to use get prediction from an estimator
@@ -52,13 +46,6 @@ def _get_response_values(
         The class considered as the positive class when computing
         the metrics. By default, `estimators.classes_[1]` is
         considered as the positive class.
-
-    target_type : str, default=None
-        The type of the target `y` as returned by
-        :func:`~sklearn.utils.multiclass.type_of_target`. If `None`, the type
-        will be inferred by calling :func:`~sklearn.utils.multiclass.type_of_target`.
-        Providing the type of the target could save time by avoid calling the
-        :func:`~sklearn.utils.multiclass.type_of_target` function.
 
     Returns
     -------
@@ -81,15 +68,15 @@ def _get_response_values(
     from sklearn.base import is_classifier  # noqa
 
     if is_classifier(estimator):
-        if target_type is None:
-            target_type = type_of_target(y_true)
         prediction_method = _check_response_method(estimator, response_method)
         y_pred = prediction_method(X)
         classes = estimator.classes_
 
+        target_type = "binary" if len(classes) <= 2 else "multiclass"
+
         if target_type == "multiclass" and prediction_method.__name__ != "predict":
             raise ValueError(
-                "With multiclass target, the response method should be "
+                "With a multiclass estimator, the response method should be "
                 f"predict, got {prediction_method.__name__} instead."
             )
 

--- a/sklearn/utils/tests/test_response.py
+++ b/sklearn/utils/tests/test_response.py
@@ -18,23 +18,20 @@ def test_get_response_values_regressor_error(response_method):
     """Check the error message with regressor an not supported response
     method."""
     my_estimator = _MockEstimatorOnOffPrediction(response_methods=[response_method])
-    X, y = "mocking_data", "mocking_target"
+    X = "mocking_data", "mocking_target"
     err_msg = f"{my_estimator.__class__.__name__} should be a classifier"
     with pytest.raises(ValueError, match=err_msg):
-        _get_response_values(my_estimator, X, y, response_method=response_method)
+        _get_response_values(my_estimator, X, response_method=response_method)
 
 
-@pytest.mark.parametrize("target_type", [None, "continuous"])
-def test_get_response_values_regressor(target_type):
+def test_get_response_values_regressor():
     """Check the behaviour of `_get_response_values` with regressor."""
     X, y = make_regression(n_samples=10, random_state=0)
     regressor = LinearRegression().fit(X, y)
     y_pred, pos_label = _get_response_values(
         regressor,
         X,
-        y,
         response_method="predict",
-        target_type=target_type,
     )
     assert_array_equal(y_pred, regressor.predict(X))
     assert pos_label is None
@@ -56,7 +53,6 @@ def test_get_response_values_classifier_unknown_pos_label(response_method):
         _get_response_values(
             classifier,
             X,
-            y,
             response_method=response_method,
             pos_label="whatever",
         )
@@ -74,13 +70,10 @@ def test_get_response_values_classifier_inconsistent_y_pred_for_binary_proba():
         r"two classes"
     )
     with pytest.raises(ValueError, match=err_msg):
-        _get_response_values(
-            classifier, X, y_two_class, response_method="predict_proba"
-        )
+        _get_response_values(classifier, X, response_method="predict_proba")
 
 
-@pytest.mark.parametrize("target_type", [None, "binary"])
-def test_get_response_values_binary_classifier_decision_function(target_type):
+def test_get_response_values_binary_classifier_decision_function():
     """Check the behaviour of `_get_response_values` with `decision_function`
     and binary classifier."""
     X, y = make_classification(
@@ -96,10 +89,8 @@ def test_get_response_values_binary_classifier_decision_function(target_type):
     y_pred, pos_label = _get_response_values(
         classifier,
         X,
-        y,
         response_method=response_method,
         pos_label=None,
-        target_type=target_type,
     )
     assert_allclose(y_pred, classifier.decision_function(X))
     assert pos_label == 1
@@ -108,17 +99,14 @@ def test_get_response_values_binary_classifier_decision_function(target_type):
     y_pred, pos_label = _get_response_values(
         classifier,
         X,
-        y,
         response_method=response_method,
         pos_label=classifier.classes_[0],
-        target_type=target_type,
     )
     assert_allclose(y_pred, classifier.decision_function(X) * -1)
     assert pos_label == 0
 
 
-@pytest.mark.parametrize("target_type", [None, "binary"])
-def test_get_response_values_binary_classifier_predict_proba(target_type):
+def test_get_response_values_binary_classifier_predict_proba():
     """Check that `_get_response_values` with `predict_proba` and binary
     classifier."""
     X, y = make_classification(
@@ -134,10 +122,8 @@ def test_get_response_values_binary_classifier_predict_proba(target_type):
     y_pred, pos_label = _get_response_values(
         classifier,
         X,
-        y,
         response_method=response_method,
         pos_label=None,
-        target_type=target_type,
     )
     assert_allclose(y_pred, classifier.predict_proba(X)[:, 1])
     assert pos_label == 1
@@ -146,10 +132,8 @@ def test_get_response_values_binary_classifier_predict_proba(target_type):
     y_pred, pos_label = _get_response_values(
         classifier,
         X,
-        y,
         response_method=response_method,
         pos_label=classifier.classes_[0],
-        target_type=target_type,
     )
     assert_allclose(y_pred, classifier.predict_proba(X)[:, 0])
     assert pos_label == 0


### PR DESCRIPTION
Suggestion for https://github.com/scikit-learn/scikit-learn/pull/23073

This PR has two commits:

1. Removing `y_true` and `target_type` from `_get_response_values` completely to simplify the code.
2. Refactor `_get_response` into `_get_response_binary` that calls `_get_response_values` with more checks. I wanted to call `_get_response_values` directly, but the display objects that use `_get_response_binary` are special cased to binary classifiers and have additional checks to make sure they are binary.

Overall, this PR reduces the amount of code.